### PR TITLE
First publish-ready version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,7 +291,7 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "kclip-cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "arboard",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
 name = "arboard"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,6 +299,7 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 name = "kclip-cli"
 version = "0.2.0"
 dependencies = [
+ "anyhow",
  "arboard",
  "clap",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,6 +302,7 @@ dependencies = [
  "anyhow",
  "arboard",
  "clap",
+ "symlink",
 ]
 
 [[package]]
@@ -560,6 +561,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,6 +65,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "app-path"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9fd3c97e161c325cea3c0e00df18732c902de9887043f74982dfd683f53e9b4"
+
+[[package]]
 name = "arboard"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,7 +127,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
 dependencies = [
  "clap_builder",
- "clap_derive",
 ]
 
 [[package]]
@@ -134,18 +139,6 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.5.47"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -270,12 +263,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
 name = "image"
 version = "0.25.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -300,6 +287,7 @@ name = "kclip-cli"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "app-path",
  "arboard",
  "clap",
  "symlink",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ default-run = "kclip"
 
 [dependencies]
 anyhow = "1.0.100"
+app-path = "1.1.2"
 arboard = "3.6.1"
-clap = { version = "4.5.48", features = ["cargo", "derive"] }
+clap = { version = "4.5.48", features = ["cargo", "string"] }
 symlink = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kclip-cli"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 default-run = "kclip"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ default-run = "kclip"
 anyhow = "1.0.100"
 arboard = "3.6.1"
 clap = { version = "4.5.48", features = ["cargo", "derive"] }
+symlink = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,11 @@
 [package]
 name = "kclip-cli"
 version = "0.2.0"
+description = "A cross-platform CLI for accessing the system clipboard "
+repository = "https://github.com/347Online/kclip-cli"
+authors = ["Katie Janzen / 347Online"]
+license = "GPL-3.0"
+
 edition = "2024"
 default-run = "kclip"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kclip-cli"
-version = "0.2.0"
+version = "0.2.1"
 description = "A cross-platform CLI for accessing the system clipboard "
 repository = "https://github.com/347Online/kclip-cli"
 authors = ["Katie Janzen / 347Online"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,6 @@ edition = "2024"
 default-run = "kclip"
 
 [dependencies]
+anyhow = "1.0.100"
 arboard = "3.6.1"
 clap = { version = "4.5.48", features = ["cargo", "derive"] }

--- a/README.md
+++ b/README.md
@@ -6,10 +6,17 @@ KClip is a cross-platform commandline utility for copying to and pasting from th
 
 KClip can be invoked in one of three ways:
 1. via the `kclip` command - this is the main binary and can be used to either copy or paste with `kclip copy` and `kclip paste`
-2. when the name of the file is `kccopy`* - reads text from std in and copies it to the system clipboard
-3. when the name of the file is `kcpaste`* - writes the contents of the system clipboard to stdout
+2. when the name of the file is `kccopy` - reads text from std in and copies it to the system clipboard
+3. when the name of the file is `kcpaste` - writes the contents of the system clipboard to stdout
 
-*See compilation section for instructions on creating symlinks for kccopy and kcpaste
+## Installation
+
+KClip is available as a binary distribution via crates.io and can be installed with cargo
+
+```sh
+cargo install kclip-cli
+kclip install # installs symlink aliases for kccopy/kcpaste
+```
 
 ## Compilation
 

--- a/src/bin/kclip.rs
+++ b/src/bin/kclip.rs
@@ -1,4 +1,4 @@
-use std::io::stdin;
+use std::io::{BufRead, Write, stdin, stdout};
 
 use arboard::Clipboard;
 use clap::{Parser, Subcommand, ValueEnum};
@@ -30,23 +30,26 @@ struct Cli {
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
+
+    let mut clipboard = Clipboard::new()?;
+
     match &cli.command {
         Commands::Kclip {
             action: Actions::Copy,
         }
         | Commands::Kccopy => {
-            let text: String = stdin().lines().map_while(Result::ok).collect();
+            let text = stdin().lock().lines().collect::<Result<String, _>>()?;
 
-            Clipboard::new().and_then(|mut cb| cb.set_text(text))?;
+            clipboard.set_text(text)?;
         }
 
         Commands::Kclip {
             action: Actions::Paste,
         }
         | Commands::Kcpaste => {
-            let text = Clipboard::new().and_then(|mut cb| cb.get_text())?;
+            let text = clipboard.get_text()?;
 
-            print!("{text}");
+            write!(stdout().lock(), "{text}")?;
         }
     }
 

--- a/src/bin/kclip.rs
+++ b/src/bin/kclip.rs
@@ -54,7 +54,7 @@ fn paste(cb: &mut Clipboard) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
     let mut cb = Clipboard::new().context("failed to access clipboard")?;


### PR DESCRIPTION
* Improve error handling
* Use a shared clipboard instance and thus a shared divergence point for errors
* Maintainability refactors
  * Subcommand functionality split out into functions vs. bloating match arms
  * Refactor to use clap builder interface rather than derive
* Add functionality for installing symlinks as part of the application