### PR TITLE
Version 0.3.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,7 @@
 name: Publish
 on:
   push:
-    branches: [main, dev] # TODO: REMOVE DEV WHEN DISABLING DRY RUN
+    branches: [main]
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -9,4 +9,4 @@ jobs:
       - uses: actions/checkout@v4
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
-      - run: cargo publish --dry-run
+      - run: cargo publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,12 @@
+name: Publish
+on:
+  push:
+    branches: [main, dev] # TODO: REMOVE DEV WHEN DISABLING DRY RUN
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - run: cargo publish --dry-run

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,7 +284,7 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "kclip-cli"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "app-path",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kclip-cli"
-version = "0.2.3"
+version = "0.3.0"
 description = "A cross-platform CLI for accessing the system clipboard "
 repository = "https://github.com/347Online/kclip-cli"
 authors = ["Katie Janzen / 347Online"]

--- a/README.md
+++ b/README.md
@@ -38,14 +38,12 @@ cargo build --release
 
 Like any Rust project, initial compilation will take longer as all associated dependencies are compiled, but later builds will be faster by virtue of incremental compilation.
 
-After building the application, you will need to place the compiled binary in a location on `$PATH`, e.g. /usr/local/bin, however this alone will not provide access to `kccopy` or `kcpaste`.
+After building the application, you will need to place the compiled binary in a location on `$PATH`, e.g. /usr/local/bin, however this alone will not provide access to `kccopy`, `kcpaste`, or `kcclear`.
 For that, it is recommended to create symlinks to wherever you placed the kclip binary in a location on `$PATH` as well. If you expect to rebuild KClip often, you can even link to the location of the compiled binary itself, which will always give you access to your latest build.
 
 ```sh
 # Execute from the base directory of the repository
-for x in {kclip,kccopy,kcpaste}; do
-  sudo ln -s "$(readlink -f ./target/release/kclip)" "/usr/local/bin/$x"
-done
+./target/debug/kclip install /usr/local/bin
 ```
 
 ### Nix-based setup

--- a/package.nix
+++ b/package.nix
@@ -10,9 +10,7 @@ rustPlatform.buildRustPackage {
   src = lib.cleanSource ./.;
 
   postInstall = ''
-    ln -fs $out/bin/kclip $out/bin/kccopy
-    ln -fs $out/bin/kclip $out/bin/kcpaste
-    ln -fs $out/bin/kclip $out/bin/kcclear
+    $out/bin/kclip install $out/bin
   '';
 
   meta.mainProgram = manifest.default-run;

--- a/package.nix
+++ b/package.nix
@@ -12,6 +12,7 @@ rustPlatform.buildRustPackage {
   postInstall = ''
     ln -fs $out/bin/kclip $out/bin/kccopy
     ln -fs $out/bin/kclip $out/bin/kcpaste
+    ln -fs $out/bin/kclip $out/bin/kcclear
   '';
 
   meta.mainProgram = manifest.default-run;

--- a/src/bin/kclip.rs
+++ b/src/bin/kclip.rs
@@ -6,22 +6,6 @@ use std::io::{BufRead, Write, stdin, stdout};
 use std::path::{Path, PathBuf};
 use symlink::symlink_file;
 
-macro_rules! primary_commands {
-    ($prefix:expr) => {
-        [
-            Command::new(concat!($prefix, "copy"))
-                .about("Copies text from stdin to the system clipboard"),
-            Command::new(concat!($prefix, "paste"))
-                .about("Pastes the contents of the system clipboard to stdout"),
-            Command::new(concat!($prefix, "clear"))
-                .about("Clears the contents of the system clipboard"),
-        ]
-    };
-    () => {
-        primary_commands!("")
-    };
-}
-
 struct App {
     cb: Clipboard,
     cli: Command,
@@ -33,8 +17,17 @@ impl App {
         let cb = Clipboard::new().context("Failed to access clipboard")?;
         let app_dir = app_path!().to_string();
 
-        let primary_commands = primary_commands!();
-        let aliased_commands = primary_commands!("kc");
+        let primary_commands = [
+            Command::new("copy").about("Copies text from stdin to the system clipboard"),
+            Command::new("paste").about("Pastes the contents of the system clipboard to stdout"),
+            Command::new("clear").about("Clears the contents of the system clipboard"),
+        ];
+        let [copy, paste, clear] = primary_commands.clone();
+        let aliased_commands = [
+            copy.name("kccopy"),
+            paste.name("kcpaste"),
+            clear.name("kcclear"),
+        ];
 
         let cli = command!("kclip")
             .multicall(true)

--- a/src/bin/kclip.rs
+++ b/src/bin/kclip.rs
@@ -6,31 +6,6 @@ use std::io::{BufRead, Write, stdin, stdout};
 use std::path::{Path, PathBuf};
 use symlink::symlink_file;
 
-fn copy(cb: &mut Clipboard) -> anyhow::Result<()> {
-    let text = stdin()
-        .lock()
-        .lines()
-        .collect::<Result<String, _>>()
-        .context("Failed to read from stdin")?;
-
-    cb.set_text(text)
-        .context("Failed write content to clipboard")?;
-
-    Ok(())
-}
-
-fn paste(cb: &mut Clipboard) -> anyhow::Result<()> {
-    let text = match cb.get_text() {
-        Ok(x) => x,
-        Err(arboard::Error::ContentNotAvailable) => return Ok(()),
-        Err(err) => Err(err).context("Failed to read contents of clipboard")?,
-    };
-
-    write!(stdout().lock(), "{text}").context("Failed to write to stdout")?;
-
-    Ok(())
-}
-
 macro_rules! primary_commands {
     ($prefix:expr) => {
         [
@@ -47,123 +22,165 @@ macro_rules! primary_commands {
     };
 }
 
-macro_rules! alias_prefix {
-    () => {
-        "kc"
-    };
+struct App {
+    cb: Clipboard,
+    cli: Command,
+    aliased_commands: [Command; 3],
 }
 
-fn install(target: &Path) -> anyhow::Result<()> {
-    let src = std::env::current_exe()?;
+impl App {
+    pub fn new() -> anyhow::Result<Self> {
+        let cb = Clipboard::new().context("Failed to access clipboard")?;
+        let app_dir = app_path!().to_string();
 
-    let commands = primary_commands!(alias_prefix!());
-    let total = commands.len();
-    let mut succeeded = 0;
+        let primary_commands = primary_commands!();
+        let aliased_commands = primary_commands!("kc");
 
-    for cmd in commands {
-        let alias = target.join(cmd.get_name());
+        let cli = command!("kclip")
+            .multicall(true)
+            .propagate_version(true)
+            .subcommands(&aliased_commands)
+            .subcommand(
+                command!("kclip")
+                    .arg_required_else_help(true)
+                    .subcommand_help_heading("COMMANDS")
+                    .subcommands(&primary_commands)
+                    .subcommand(
+                        Command::new("install")
+                            .about("Install symlink aliases")
+                            .arg(
+                                Arg::new("TARGET")
+                                    .help("Install symlink aliases to specified target")
+                                    .value_name("TARGET")
+                                    .default_value(&app_dir)
+                                    .value_parser(value_parser!(PathBuf)),
+                            ),
+                    )
+                    .subcommand(
+                        Command::new("inspect")
+                            .about("Display information about the current clipboard content"),
+                    ),
+            );
 
-        match symlink_file(&src, &alias)
-            .context(format!("Failed to symlink {:?} -> {:?}", &src, alias))
-        {
-            Ok(_) => succeeded += 1,
-            Err(err) => {
-                eprintln!("{err}");
-                if let Some(cause) = err.source() {
-                    eprintln!("   {cause}");
+        Ok(App {
+            cb,
+            cli,
+            aliased_commands,
+        })
+    }
+
+    fn copy(&mut self) -> anyhow::Result<()> {
+        let text = stdin()
+            .lock()
+            .lines()
+            .collect::<Result<String, _>>()
+            .context("Failed to read from stdin")?;
+
+        self.cb
+            .set_text(text)
+            .context("Failed write content to clipboard")?;
+
+        Ok(())
+    }
+
+    fn paste(&mut self) -> anyhow::Result<()> {
+        let text = match self.cb.get_text() {
+            Ok(x) => x,
+            Err(arboard::Error::ContentNotAvailable) => return Ok(()),
+            Err(err) => Err(err).context("Failed to read contents of clipboard")?,
+        };
+
+        write!(stdout().lock(), "{text}").context("Failed to write to stdout")?;
+
+        Ok(())
+    }
+
+    fn install(&self, target: &Path) -> anyhow::Result<()> {
+        let src = std::env::current_exe()?;
+
+        let total = self.aliased_commands.len();
+        let mut succeeded = 0;
+
+        for cmd in &self.aliased_commands {
+            let alias = target.join(cmd.get_name());
+
+            match symlink_file(&src, &alias)
+                .context(format!("Failed to symlink {:?} -> {:?}", &src, alias))
+            {
+                Ok(_) => succeeded += 1,
+                Err(err) => {
+                    eprintln!("{err}");
+                    if let Some(cause) = err.source() {
+                        eprintln!("   {cause}");
+                    }
                 }
             }
         }
+
+        if succeeded == total {
+            println!("All aliases installed successfully");
+        } else {
+            println!("{succeeded}/{total} aliases installed successfully");
+            std::process::exit(1);
+        }
+
+        Ok(())
     }
 
-    if succeeded == total {
-        println!("All aliases installed successfully");
-    } else {
-        println!("{succeeded}/{total} aliases installed successfully");
-        std::process::exit(1);
+    fn clear(&mut self) -> anyhow::Result<()> {
+        Ok(self.cb.clear()?)
     }
 
-    Ok(())
-}
+    fn inspect(&mut self) {
+        let repr = if let Ok(_paths) = self.cb.get().file_list() {
+            "files"
+        } else if let Ok(_image) = self.cb.get().image() {
+            "image"
+        } else if let Ok(_html) = self.cb.get().html() {
+            "html"
+        } else if let Ok(_text) = self.cb.get().text() {
+            "text"
+        } else {
+            "<empty>"
+        };
 
-fn clear(cb: &mut Clipboard) -> anyhow::Result<()> {
-    Ok(cb.clear()?)
-}
+        println!("{repr}");
+    }
 
-fn inspect(cb: &mut Clipboard) {
-    let repr = if let Ok(_paths) = cb.get().file_list() {
-        "files"
-    } else if let Ok(_image) = cb.get().image() {
-        "image"
-    } else if let Ok(_html) = cb.get().html() {
-        "html"
-    } else if let Ok(_text) = cb.get().text() {
-        "text"
-    } else {
-        "<empty>"
-    };
+    pub fn invoke(mut self) -> anyhow::Result<()> {
+        let cli = std::mem::take(&mut self.cli);
+        let matches = cli.get_matches();
 
-    println!("{repr}");
-}
+        let subcommand = matches.subcommand().and_then(|x| {
+            if let ("kclip", cmd) = x {
+                cmd.subcommand()
+            } else {
+                Some(x)
+            }
+        });
 
-fn cli(app_dir: String) -> Command {
-    command!("kclip")
-        .multicall(true)
-        .propagate_version(true)
-        .subcommands(primary_commands!(alias_prefix!()))
-        .subcommand(
-            command!("kclip")
-                .arg_required_else_help(true)
-                .subcommand_help_heading("COMMANDS")
-                .subcommands(primary_commands!())
-                .subcommand(
-                    Command::new("install")
-                        .about("Install symlink aliases")
-                        .arg(
-                            Arg::new("TARGET")
-                                .help("Install symlink aliases to specified target")
-                                .value_name("TARGET")
-                                .default_value(app_dir)
-                                .value_parser(value_parser!(PathBuf)),
-                        ),
-                )
-                .subcommand(
-                    Command::new("inspect")
-                        .about("Display information about the current clipboard content"),
-                ),
-        )
+        match subcommand {
+            Some(("kccopy" | "copy", _)) => self.copy()?,
+            Some(("kcpaste" | "paste", _)) => self.paste()?,
+            Some(("kcclear" | "clear", _)) => self.clear()?,
+            Some(("inspect", _)) => self.inspect(),
+            Some(("install", cmd)) => {
+                let target = cmd
+                    .get_one::<PathBuf>("TARGET")
+                    .expect("TARGET should always have a value");
+
+                self.install(target)?;
+            }
+
+            _ => unreachable!("parser should ensure only valid names are used"),
+        }
+
+        Ok(())
+    }
 }
 
 fn main() -> anyhow::Result<()> {
-    let app_dir = app_path!().to_string();
-    let cmd = cli(app_dir);
+    let app = App::new()?;
 
-    let mut cb = Clipboard::new().context("Failed to access clipboard")?;
-
-    let matches = cmd.get_matches();
-    let subcommand = matches.subcommand().and_then(|x| {
-        if let ("kclip", cmd) = x {
-            cmd.subcommand()
-        } else {
-            Some(x)
-        }
-    });
-
-    match subcommand {
-        Some(("kccopy" | "copy", _)) => copy(&mut cb)?,
-        Some(("kcpaste" | "paste", _)) => paste(&mut cb)?,
-        Some(("kcclear" | "clear", _)) => clear(&mut cb)?,
-        Some(("inspect", _)) => inspect(&mut cb),
-        Some(("install", cmd)) => {
-            let target = cmd
-                .get_one::<PathBuf>("TARGET")
-                .expect("TARGET should always have a value");
-
-            install(target)?;
-        }
-
-        _ => unreachable!("parser should ensure only valid names are used"),
-    }
-
-    Ok(())
+    app.invoke()
 }

--- a/src/bin/kclip.rs
+++ b/src/bin/kclip.rs
@@ -8,175 +8,172 @@ use symlink::symlink_file;
 
 const ALIASES: [&str; 4] = ["kclip", "kccopy", "kcpaste", "kcclear"];
 
-struct App {
-    cb: Clipboard,
-    cli: Command,
+fn get_clipboard() -> anyhow::Result<Clipboard> {
+    Clipboard::new().context("Failed to access clipboard")
 }
 
-impl App {
-    pub fn new() -> anyhow::Result<Self> {
-        let cb = Clipboard::new().context("Failed to access clipboard")?;
-        let app_dir = app_path!().to_string();
+fn copy() -> anyhow::Result<()> {
+    let text = stdin()
+        .lock()
+        .lines()
+        .collect::<Result<String, _>>()
+        .context("Failed to read from stdin")?;
 
-        let primary_commands = [
-            Command::new("copy").about("Copies text from stdin to the system clipboard"),
-            Command::new("paste").about("Pastes the contents of the system clipboard to stdout"),
-            Command::new("clear").about("Clears the contents of the system clipboard"),
-        ];
-        let [copy, paste, clear] = primary_commands.clone();
-        let aliased_commands = [
-            copy.name("kccopy"),
-            paste.name("kcpaste"),
-            clear.name("kcclear"),
-        ];
+    get_clipboard()?
+        .set_text(text)
+        .context("Failed write content to clipboard")?;
 
-        let cli = command!("kclip")
-            .multicall(true)
-            .propagate_version(true)
-            .subcommands(&aliased_commands)
-            .subcommand(
-                command!("kclip")
-                    .arg_required_else_help(true)
-                    .subcommand_help_heading("COMMANDS")
-                    .subcommands(&primary_commands)
-                    .subcommand(
-                        Command::new("install")
-                            .about("Install symlink aliases")
-                            .arg(
-                                Arg::new("TARGET")
-                                    .help("Install symlink aliases to specified target")
-                                    .value_name("TARGET")
-                                    .default_value(&app_dir)
-                                    .value_parser(value_parser!(PathBuf)),
-                            ),
-                    )
-                    .subcommand(
-                        Command::new("inspect")
-                            .about("Display information about the current clipboard content"),
-                    ),
-            );
+    Ok(())
+}
 
-        Ok(App { cb, cli })
-    }
+fn paste() -> anyhow::Result<()> {
+    let text = match get_clipboard()?.get_text() {
+        Ok(x) => x,
+        Err(arboard::Error::ContentNotAvailable) => return Ok(()),
+        Err(err) => Err(err).context("Failed to read contents of clipboard")?,
+    };
 
-    fn copy(&mut self) -> anyhow::Result<()> {
-        let text = stdin()
-            .lock()
-            .lines()
-            .collect::<Result<String, _>>()
-            .context("Failed to read from stdin")?;
+    write!(stdout().lock(), "{text}").context("Failed to write to stdout")?;
 
-        self.cb
-            .set_text(text)
-            .context("Failed write content to clipboard")?;
+    Ok(())
+}
 
-        Ok(())
-    }
+fn install(target: &Path) -> anyhow::Result<()> {
+    let src = std::env::current_exe()?;
 
-    fn paste(&mut self) -> anyhow::Result<()> {
-        let text = match self.cb.get_text() {
-            Ok(x) => x,
-            Err(arboard::Error::ContentNotAvailable) => return Ok(()),
-            Err(err) => Err(err).context("Failed to read contents of clipboard")?,
-        };
+    let external = target.as_os_str() != app_path!().as_os_str();
 
-        write!(stdout().lock(), "{text}").context("Failed to write to stdout")?;
+    let aliases = if external {
+        Vec::from(ALIASES)
+    } else {
+        Vec::from(&ALIASES[1..])
+    };
+    let total = aliases.len();
+    let mut succeeded = 0;
 
-        Ok(())
-    }
+    for cmd in aliases {
+        let alias = target.join(cmd);
 
-    fn install(&self, target: &Path) -> anyhow::Result<()> {
-        let src = std::env::current_exe()?;
-
-        let external = target.as_os_str() != app_path!().as_os_str();
-
-        let aliases = if external {
-            Vec::from(ALIASES)
-        } else {
-            Vec::from(&ALIASES[1..])
-        };
-        let total = aliases.len();
-        let mut succeeded = 0;
-
-        for cmd in aliases {
-            let alias = target.join(cmd);
-
-            match symlink_file(&src, &alias)
-                .context(format!("Failed to symlink {:?} -> {:?}", &src, alias))
-            {
-                Ok(_) => succeeded += 1,
-                Err(err) => {
-                    eprintln!("{err}");
-                    if let Some(cause) = err.source() {
-                        eprintln!("   {cause}");
-                    }
+        match symlink_file(&src, &alias)
+            .context(format!("Failed to symlink {:?} -> {:?}", &src, alias))
+        {
+            Ok(_) => succeeded += 1,
+            Err(err) => {
+                eprintln!("{err}");
+                if let Some(cause) = err.source() {
+                    eprintln!("   {cause}");
                 }
             }
         }
-
-        println!("{succeeded}/{total} aliases installed successfully");
-
-        if succeeded != total {
-            std::process::exit(1);
-        }
-
-        Ok(())
     }
 
-    fn clear(&mut self) -> anyhow::Result<()> {
-        Ok(self.cb.clear()?)
+    println!("{succeeded}/{total} aliases installed successfully");
+
+    if succeeded != total {
+        std::process::exit(1);
     }
 
-    fn inspect(&mut self) {
-        let repr = if let Ok(_paths) = self.cb.get().file_list() {
-            "files"
-        } else if let Ok(_image) = self.cb.get().image() {
-            "image"
-        } else if let Ok(_html) = self.cb.get().html() {
-            "html"
-        } else if let Ok(_text) = self.cb.get().text() {
-            "text"
+    Ok(())
+}
+
+fn clear() -> anyhow::Result<()> {
+    Ok(get_clipboard()?.clear()?)
+}
+
+fn inspect() -> anyhow::Result<()> {
+    let repr = if let Ok(_paths) = get_clipboard()?.get().file_list() {
+        "files"
+    } else if let Ok(_image) = get_clipboard()?.get().image() {
+        "image"
+    } else if let Ok(_html) = get_clipboard()?.get().html() {
+        "html"
+    } else if let Ok(_text) = get_clipboard()?.get().text() {
+        "text"
+    } else {
+        "<empty>"
+    };
+
+    println!("{repr}");
+
+    Ok(())
+}
+
+fn init() -> Command {
+    let app_dir = app_path!().to_string();
+
+    let primary_commands = [
+        Command::new("copy").about("Copies text from stdin to the system clipboard"),
+        Command::new("paste").about("Pastes the contents of the system clipboard to stdout"),
+        Command::new("clear").about("Clears the contents of the system clipboard"),
+    ];
+
+    let [copy, paste, clear] = primary_commands.clone();
+
+    let aliased_commands = [
+        copy.name("kccopy"),
+        paste.name("kcpaste"),
+        clear.name("kcclear"),
+    ];
+
+    command!("kclip")
+        .multicall(true)
+        .propagate_version(true)
+        .subcommands(&aliased_commands)
+        .subcommand(
+            command!("kclip")
+                .arg_required_else_help(true)
+                .subcommand_help_heading("COMMANDS")
+                .subcommands(&primary_commands)
+                .subcommand(
+                    Command::new("install")
+                        .about("Install symlink aliases")
+                        .arg(
+                            Arg::new("TARGET")
+                                .help("Install symlink aliases to specified target")
+                                .value_name("TARGET")
+                                .default_value(&app_dir)
+                                .value_parser(value_parser!(PathBuf)),
+                        ),
+                )
+                .subcommand(
+                    Command::new("inspect")
+                        .about("Display information about the current clipboard content"),
+                ),
+        )
+}
+
+fn run(cmd: Command) -> anyhow::Result<()> {
+    let matches = cmd.get_matches();
+
+    let subcommand = matches.subcommand().and_then(|x| {
+        if let ("kclip", cmd) = x {
+            cmd.subcommand()
         } else {
-            "<empty>"
-        };
+            Some(x)
+        }
+    });
 
-        println!("{repr}");
-    }
+    match subcommand {
+        Some(("kccopy" | "copy", _)) => copy()?,
+        Some(("kcpaste" | "paste", _)) => paste()?,
+        Some(("kcclear" | "clear", _)) => clear()?,
+        Some(("inspect", _)) => inspect()?,
+        Some(("install", cmd)) => {
+            let target = cmd
+                .get_one::<PathBuf>("TARGET")
+                .expect("TARGET should always have a value");
 
-    pub fn invoke(mut self) -> anyhow::Result<()> {
-        let cli = std::mem::take(&mut self.cli);
-        let matches = cli.get_matches();
-
-        let subcommand = matches.subcommand().and_then(|x| {
-            if let ("kclip", cmd) = x {
-                cmd.subcommand()
-            } else {
-                Some(x)
-            }
-        });
-
-        match subcommand {
-            Some(("kccopy" | "copy", _)) => self.copy()?,
-            Some(("kcpaste" | "paste", _)) => self.paste()?,
-            Some(("kcclear" | "clear", _)) => self.clear()?,
-            Some(("inspect", _)) => self.inspect(),
-            Some(("install", cmd)) => {
-                let target = cmd
-                    .get_one::<PathBuf>("TARGET")
-                    .expect("TARGET should always have a value");
-
-                self.install(target)?;
-            }
-
-            _ => unreachable!("parser should ensure only valid names are used"),
+            install(target)?;
         }
 
-        Ok(())
+        _ => unreachable!("parser should ensure only valid names are used"),
     }
+
+    Ok(())
 }
 
 fn main() -> anyhow::Result<()> {
-    let app = App::new()?;
+    let cmd = init();
 
-    app.invoke()
+    run(cmd)
 }

--- a/src/bin/kclip.rs
+++ b/src/bin/kclip.rs
@@ -31,7 +31,7 @@ fn paste(cb: &mut Clipboard) -> anyhow::Result<()> {
     Ok(())
 }
 
-macro_rules! applet_commands {
+macro_rules! primary_commands {
     ($prefix:expr) => {
         [
             Command::new(concat!($prefix, "copy"))
@@ -41,7 +41,7 @@ macro_rules! applet_commands {
         ]
     };
     () => {
-        applet_commands!("")
+        primary_commands!("")
     };
 }
 
@@ -54,7 +54,7 @@ macro_rules! alias_prefix {
 fn install(target: &Path) -> anyhow::Result<()> {
     let src = std::env::current_exe()?;
 
-    let commands = applet_commands!(alias_prefix!());
+    let commands = primary_commands!(alias_prefix!());
     let total = commands.len();
     let mut succeeded = 0;
 
@@ -88,12 +88,12 @@ fn cli(app_dir: String) -> Command {
     command!("kclip")
         .multicall(true)
         .propagate_version(true)
-        .subcommands(applet_commands!(alias_prefix!()))
+        .subcommands(primary_commands!(alias_prefix!()))
         .subcommand(
             command!("kclip")
                 .arg_required_else_help(true)
                 .subcommand_help_heading("COMMANDS")
-                .subcommands(applet_commands!())
+                .subcommands(primary_commands!())
                 .subcommand(
                     Command::new("install")
                         .arg(


### PR DESCRIPTION
# Features

* New commands:
  * `kclip clear` / `kcclear` — Clears the contents of the clipboard
  * `kclip inspect` — Prints the type of data present on the clipboard `image|text|<empty>`
* Make `kclip install` a little smarter
  * Attempts to install a symlink for the `kclip` command itself, in addition to its aliases `kccopy`, `kcpaste`, and `kcclear` to the specified location, skipping this first link if installing to the binary's location (the default behavior of `kclip install` without passing a path

# Architecture
* Revert to deferring clipboard access until an operation is being performed to support running `kclip install` in a headless session in which the clipboard is unavailable (such as when building via Nix)
* Refactor how re-use is implemented for the primary commands and their aliased counterparts to be less clunky
* Add a publish workflow in GitHub actions